### PR TITLE
Remove bi_connector from advanced_cluster reconciliation

### DIFF
--- a/apis/mongodbatlas/v1alpha2/zz_generated_terraformed.go
+++ b/apis/mongodbatlas/v1alpha2/zz_generated_terraformed.go
@@ -89,6 +89,7 @@ func (tr *AdvancedCluster) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("BiConnector"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/config/mongodbatlas/config.go
+++ b/config/mongodbatlas/config.go
@@ -52,6 +52,9 @@ func Configure(p *config.Provider) {
 			}
 			return common.Base64EncodeTokens("cluster_id", parts[1], "cluster_name", parameters["name"], "project_id", parameters["project_id"])
 		}
+		r.LateInitializer = config.LateInitializer{
+			IgnoredFields: []string{"bi_connector"},
+		}
 		r.UseAsync = true
 	})
 }


### PR DESCRIPTION
### Description of your changes

`bi_connector` and `bi_connector_config` are conflicting fields in the `mongodbatlas_advanced_cluster` resource.
This PR removes the deprecated bi_connector field from late_initialization to prevent this conflict on first observe.
