### PR TITLE
docs(examples): use public_key/private_key in ProviderConfig credentials

### DIFF
--- a/examples/cluster/providerconfig/clusterproviderconfig.yaml
+++ b/examples/cluster/providerconfig/clusterproviderconfig.yaml
@@ -19,6 +19,6 @@ type: Opaque
 stringData:
   credentials: |
     {
-      "publicKey": "your-public-key",
-      "privateKey": "your-private-key"
+      "public_key": "your-public-key",
+      "private_key": "your-private-key"
     }

--- a/examples/cluster/providerconfig/providerconfig-env.yaml
+++ b/examples/cluster/providerconfig/providerconfig-env.yaml
@@ -8,5 +8,5 @@ spec:
     env:
       name: MONGODBATLAS_CREDENTIALS
 # The environment variable must contain the credentials JSON:
-#   MONGODBATLAS_CREDENTIALS='{"publicKey":"your-public-key","privateKey":"your-private-key"}'
+#   MONGODBATLAS_CREDENTIALS='{"public_key":"your-public-key","private_key":"your-private-key"}'
 # Set this on the provider pod via a DeploymentRuntimeConfig.

--- a/examples/cluster/providerconfig/providerconfig.yaml
+++ b/examples/cluster/providerconfig/providerconfig.yaml
@@ -19,6 +19,6 @@ type: Opaque
 stringData:
   credentials: |
     {
-      "publicKey": "your-public-key",
-      "privateKey": "your-private-key"
+      "public_key": "your-public-key",
+      "private_key": "your-private-key"
     }

--- a/examples/namespaced/providerconfig/providerconfig-env.yaml
+++ b/examples/namespaced/providerconfig/providerconfig-env.yaml
@@ -9,5 +9,5 @@ spec:
     env:
       name: MONGODBATLAS_CREDENTIALS
 # The environment variable must contain the credentials JSON:
-#   MONGODBATLAS_CREDENTIALS='{"publicKey":"your-public-key","privateKey":"your-private-key"}'
+#   MONGODBATLAS_CREDENTIALS='{"public_key":"your-public-key","private_key":"your-private-key"}'
 # Set this on the provider pod via a DeploymentRuntimeConfig.

--- a/examples/namespaced/providerconfig/providerconfig.yaml
+++ b/examples/namespaced/providerconfig/providerconfig.yaml
@@ -20,6 +20,6 @@ type: Opaque
 stringData:
   credentials: |
     {
-      "publicKey": "your-public-key",
-      "privateKey": "your-private-key"
+      "public_key": "your-public-key",
+      "private_key": "your-private-key"
     }


### PR DESCRIPTION
### Description of changes

  The ProviderConfig examples use camelCase credential keys (`publicKey` / `privateKey`), but `internal/clients/mongodbatlas.go` reads snake_case (`public_key` / `private_key`).
  Following the examples produces an empty credentials map, and the provider then authenticates with an empty digest username, Atlas returns a 401 that is indistinguishable from a revoked or wrong API key.

  This corrects the five example manifests to match the code. Docs-only; no code paths change.

  Fixes #172

  I have:

  - [x] Read and followed Crossplane's [contribution process].

  ### How has this code been tested

  Docs-only change to example manifests; no code paths are affected. Verified against `internal/clients/mongodbatlas.go#L41-L42`, which reads `public_key`/`private_key`, and confirmed that
  the corrected format authenticates successfully against the Atlas Admin API from a live cluster.

  I did not run the full `make reviewable test`, it regenerates `zz_generated.*`, `examples-generated/` and `package/crds/`, which would add unrelated churn to a YAML-only change. Happy to run it if preferred.

  [contribution process]: https://git.io/fj2m9